### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-physx.yml
+++ b/.github/workflows/build-physx.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup target add x86_64-pc-windows-msvc
       - run: cargo build --target x86_64-pc-windows-msvc --release
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: win-x64
           path: ./src/libmagicphysx/target/x86_64-pc-windows-msvc/release/magicphysx.dll
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup target add x86_64-unknown-linux-gnu
       - run: cargo build --target x86_64-unknown-linux-gnu --release
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: linux-x64
           path: ./src/libmagicphysx/target/x86_64-unknown-linux-gnu/release/libmagicphysx.so
@@ -91,7 +91,7 @@ jobs:
         with:
           target: aarch64-unknown-linux-gnu
       - run: cargo build --target aarch64-unknown-linux-gnu --release
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: linux-arm64
           path: ./src/libmagicphysx/target/aarch64-unknown-linux-gnu/release/libmagicphysx.so
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup target add x86_64-apple-darwin
       - run: cargo build --target x86_64-apple-darwin --release
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: osx-x64
           path: ./src/libmagicphysx/target/x86_64-apple-darwin/release/libmagicphysx.dylib
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup target add aarch64-apple-darwin
       - run: cargo build --target aarch64-apple-darwin --release
-      - uses: actions/upload-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: osx-arm64
           path: ./src/libmagicphysx/target/aarch64-apple-darwin/release/libmagicphysx.dylib
@@ -139,24 +139,24 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
         with:
           name: win-x64
           path: src/MagicPhysX/runtimes/win-x64/native/
       - run: mv ./src/MagicPhysX/runtimes/win-x64/native/magicphysx.dll ./src/MagicPhysX/runtimes/win-x64/native/libmagicphysx.dll
-      - uses: actions/download-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
         with:
           name: linux-x64
           path: src/MagicPhysX/runtimes/linux-x64/native
-      - uses: actions/download-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
         with:
           name: linux-arm64
           path: src/MagicPhysX/runtimes/linux-arm64/native
-      - uses: actions/download-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
         with:
           name: osx-x64
           path: src/MagicPhysX/runtimes/osx-x64/native
-      - uses: actions/download-artifact@v3
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
         with:
           name: osx-arm64
           path: src/MagicPhysX/runtimes/osx-arm64/native

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,7 +26,7 @@ jobs:
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish/

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           name: nuget
           path: ./publish/
+          retention-days: 1
 
   create-release:
     needs: [build-dotnet]


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
