### PR TITLE
ci: Pinning third party GitHub Actions sha

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly" # Check for updates to GitHub Actions every week
+    ignore:
+      # I just want update action when major/minor version is updated. patch updates are too noisy.
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-patch

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
         with:
           dotnet-version: 7.0.x
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
         with:
           dotnet-version: 7.0.x
@@ -38,7 +38,7 @@ jobs:
   #     image: mcr.microsoft.com/dotnet/aspnet:7.0.8-jammy-arm64v8
   #   timeout-minutes: 30
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   #     - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
   #       with:
   #         dotnet-version: 7.0.x
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
         with:
           dotnet-version: 7.0.x

--- a/.github/workflows/build-physx.yml
+++ b/.github/workflows/build-physx.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: ./src/libmagicphysx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: cargo test update_package_version -- ${{ inputs.physxversion }} --nocapture
 
       - name: Check update
@@ -33,7 +33,7 @@ jobs:
 
       - name: Push changes
         if: ${{ steps.check_update.outputs.changed == '1' }}
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
@@ -49,7 +49,7 @@ jobs:
       run:
         working-directory: ./src/libmagicphysx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: rustup target add x86_64-pc-windows-msvc
       - run: cargo build --target x86_64-pc-windows-msvc --release
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
@@ -66,7 +66,7 @@ jobs:
       run:
         working-directory: ./src/libmagicphysx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: rustup target add x86_64-unknown-linux-gnu
       - run: cargo build --target x86_64-unknown-linux-gnu --release
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
@@ -86,7 +86,7 @@ jobs:
       run:
         working-directory: ./src/libmagicphysx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: aarch64-unknown-linux-gnu
@@ -105,7 +105,7 @@ jobs:
       run:
         working-directory: ./src/libmagicphysx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: rustup target add x86_64-apple-darwin
       - run: cargo build --target x86_64-apple-darwin --release
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
@@ -122,7 +122,7 @@ jobs:
       run:
         working-directory: ./src/libmagicphysx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: rustup target add aarch64-apple-darwin
       - run: cargo build --target aarch64-apple-darwin --release
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/download-artifact@main
         with:
           name: win-x64
@@ -166,7 +166,7 @@ jobs:
           git add --all
           git commit -m "Update physx lib runtime" -a
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
         with:
           dotnet-version: 7.0.x


### PR DESCRIPTION
## tl;dr;

Follow to the GitHub recommendation pinning third party actions sha.